### PR TITLE
Cannot read property 'hasOwnProperty' of null

### DIFF
--- a/src/cache.service.ts
+++ b/src/cache.service.ts
@@ -314,9 +314,9 @@ export class CacheService {
    * @return {boolean} - data from cache
    */
   public static isRequest(data: any): boolean {
-    if (data instanceof Request || (typeof data === 'object' && data.hasOwnProperty('_body') && data.hasOwnProperty('status') &&
+    if (data && (data instanceof Request || (typeof data === 'object' && data.hasOwnProperty('_body') && data.hasOwnProperty('status') &&
       data.hasOwnProperty('statusText') && data.hasOwnProperty('type') && data.hasOwnProperty('headers')
-      && data.hasOwnProperty('url'))) {
+      && data.hasOwnProperty('url')))) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
"Cannot read property 'hasOwnProperty' of null" error has been fixed in isRequest(), when data parameter of saveItem() is null.