### PR TITLE
Unsubscribe from original request

### DIFF
--- a/src/cache.service.ts
+++ b/src/cache.service.ts
@@ -3,7 +3,7 @@ import { HttpResponse } from '@angular/common/http';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { defer, from, fromEvent, merge, throwError } from 'rxjs';
 import { share, map, catchError, finalize } from 'rxjs/operators';
-  import { CacheStorageService, StorageCacheItem } from './cache-storage';
+import { CacheStorageService, StorageCacheItem } from './cache-storage';
 
 export interface CacheConfig {
   keyPrefix?: string;
@@ -33,7 +33,6 @@ const isHttpResponse = (data: any): boolean => {
     data.hasOwnProperty('headers') &&
     data.hasOwnProperty('url') &&
     data.hasOwnProperty('body');
-  
   return data && (data instanceof HttpResponse || orCondition);
 };
 


### PR DESCRIPTION
This change will give the same result experienced when using a regular HTTP call and when using loadFromObservable/loadFromDelayedObservable. The request passed into the method will be unsubscribed from when the returned observable is finalized (done or unsubscribed).